### PR TITLE
Add `--[no-]unindent` for removing leading indentation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,16 @@ struct Args {
     #[clap(short, long)]
     discord: bool,
 
+    /// Wrap the output in a Discord-flavoured-markdown–style ANSI codeblock.
+    #[clap(short, long, overrides_with = "_no_discord")]
+    discord: bool,
+
+    /// Don't wrap the output in a markdown-style codeblock. [default]
+    #[clap(short = 'D', long = "no-discord")]
+    #[clap(hide_short_help = true)]
+    #[doc(hidden)]
+    _no_discord: bool,
+
     // Logically this comes after `Args::strip_ansi`, but in clap it makes more sense before.
     // Also see https://jwodder.github.io/kbits/posts/clap-bool-negate/
     /// Strip all ANSI escape sequences from the input before processing. [default]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,6 @@ struct Args {
     /// The input path. If unset, stdin is used.
     input: Option<PathBuf>,
 
-    /// Whether the input should be formatted to be Discord-compatible.
-    #[clap(short, long)]
-    discord: bool,
-
     /// Wrap the output in a Discord-flavoured-markdown–style ANSI codeblock.
     #[clap(short, long, overrides_with = "_no_discord")]
     discord: bool,
@@ -112,7 +108,9 @@ fn main() -> Result<()> {
         &input
     };
 
-    if args.strip_ansi {
+    // If the input doesn't contain escape sequences, avoid processing it because strip-ansi-escapes
+    // also strips tabs unfortunately. (https://github.com/luser/strip-ansi-escapes/issues/20)
+    if args.strip_ansi && stripped.contains('\x1B') {
         input = strip_ansi_escapes::strip_str(stripped);
         stripped = &input;
     }


### PR DESCRIPTION
- **Add --[no]-unindent**
  - Should this be the default?
- **Add --no-discord for consistency**
- **Temporarily work around https://github.com/luser/strip-ansi-escapes/issues/20**
  - Let me know what you think. I realised this bug was already present while testing my dedent code and narrowed it down to `strip-ansi-escapes` (or one of its dependencies).
